### PR TITLE
add target to footer Facebook link to open in new tab

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -15,7 +15,7 @@
 	</div>
 
 	<div class="right-info">
-	<p><a href="https://www.facebook.com/pages/Humble-Hearts-Organization/477172595731068"><i class="fa fa-facebook-square fa-2x"></i></a></p>
+	<p><a href="https://www.facebook.com/pages/Humble-Hearts-Organization/477172595731068" target="_blank"><i class="fa fa-facebook-square fa-2x"></i></a></p>
 	<p>773-322-2997</p>
 	<p><a href="mailto:humblehearts@email.com" >humblehearts@email.com</a></p>
 	<p class="copyright">© Humble Hearts NFP, ORG</p>


### PR DESCRIPTION
Tiny change to make footer Facebook link open in a new tab.
