### PR TITLE
Flickr graceful fail

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -4,5 +4,10 @@ module EventsHelper
     user = flickr.users('humbleheartsorg@yahoo.com')
     list = user.photos
     arr_one, arr_two, arr_three, arr_four, arr_five = *list.group_by { |x| x[:title] }.map(&:last)
+	rescue => e
+		# Log API error
+		puts e
+		# Fallback on hardcoded images if Flickr API fails
+		albums = []
 	end
 end

--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -1,2 +1,0 @@
-module MediaHelper
-end

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -1,2 +1,0 @@
-module ServiceHelper
-end

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -1,2 +1,0 @@
-module WelcomeHelper
-end


### PR DESCRIPTION
If, for whatever reason, the API fails or blows up, this should save the user from seeing any kind of error. Rather, the events page will simply load without displaying the Flickr feed. I gave a few tests by trying the wrong API key and setting back. Seems to work as intended.

`puts e` will log the specific error in the console. In most cases, this will allow us to do Ctrl+F on the Heroku logs to check for 'Invalid API Key'.

`albums = []` can be replaced with hardcoded images to fallback on.

Also, removed empty helper files in a separate commit on this branch.
