### PR TITLE
fixed media update/delete issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    spring (1.3.5)
+    spring (1.3.6)
     sprockets (3.0.3)
       rack (~> 1.0)
     sprockets-rails (2.2.4)

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -25,14 +25,14 @@ class MediaController < ApplicationController
   end
 
   def update
-    @medium = Medium.find(params:[:id])
+    @medium = Medium.find(params[:id])
     if @medium.update(medium_params)
       redirect_to administration_path
     end
   end
 
   def delete
-    @medium = Medium.find(params:[:id])
+    @medium = Medium.find(params[:id])
     if @medium.destroy
       redirect_to administration_path
     else


### PR DESCRIPTION
When logging into the admin section of the live site, I was unable to successfully edit or delete any media entry. When looking at the code, I noticed that the first line of the edit and delete methods in media_controller.rb was "@medium = Medium.find(params:[:id])". I removed the first colon (@medium = Medium.find(params[:id])) for both methods, which seemed to fix this issue.
