### PR TITLE
removed colons after params in update and delete methods

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -25,14 +25,14 @@ class MediaController < ApplicationController
   end
 
   def update
-    @medium = Medium.find(params:[:id])
+    @medium = Medium.find(params[:id])
     if @medium.update(medium_params)
       redirect_to administration_path
     end
   end
 
   def delete
-    @medium = Medium.find(params:[:id])
+    @medium = Medium.find(params[:id])
     if @medium.destroy
       redirect_to administration_path
     else


### PR DESCRIPTION
When logging into the admin section of the live site, I was unable to successfully edit or delete any media entry. When looking at the code, I noticed that the first line of the edit and delete methods in media_controller.rb was "@medium = Medium.find(params:[:id])". I removed the first colon (@medium = Medium.find(params[:id])) for both methods, which seemed to fix this issue.
